### PR TITLE
rutabaga_gfx: don't clone wayland memfd file descriptor

### DIFF
--- a/rutabaga_gfx/src/rutabaga_core.rs
+++ b/rutabaga_gfx/src/rutabaga_core.rs
@@ -757,7 +757,6 @@ impl Rutabaga {
                         ));
                     }
 
-                    let clone = handle.try_clone()?;
                     let resource_size: usize = resource.size.try_into()?;
                     let map_info = resource
                         .map_info
@@ -765,7 +764,7 @@ impl Rutabaga {
 
                     // Creating the mapping closes the cloned descriptor.
                     let mapping = MemoryMapping::from_safe_descriptor(
-                        clone.os_handle,
+                        &handle.os_handle,
                         resource_size,
                         map_info,
                     )?;

--- a/rutabaga_gfx/src/rutabaga_os/memory_mapping.rs
+++ b/rutabaga_gfx/src/rutabaga_os/memory_mapping.rs
@@ -13,7 +13,7 @@ pub struct MemoryMapping {
 
 impl MemoryMapping {
     pub fn from_safe_descriptor(
-        descriptor: SafeDescriptor,
+        descriptor: &SafeDescriptor,
         size: usize,
         map_info: u32,
     ) -> RutabagaResult<MemoryMapping> {

--- a/rutabaga_gfx/src/rutabaga_os/sys/linux/memory_mapping.rs
+++ b/rutabaga_gfx/src/rutabaga_os/sys/linux/memory_mapping.rs
@@ -38,7 +38,7 @@ impl Drop for MemoryMapping {
 
 impl MemoryMapping {
     pub fn from_safe_descriptor(
-        descriptor: SafeDescriptor,
+        descriptor: &SafeDescriptor,
         size: usize,
         map_info: u32,
     ) -> RutabagaResult<MemoryMapping> {


### PR DESCRIPTION
After cloning these file descriptor mmap will fail on the new file descriptor. This results in mmap errors.

We don't accept any GitHub pull requests to crosvm. We use
[Chromium Gerrit](https://chromium-review.googlesource.com/) for the code review process. See
[the contribution guide](https://crosvm.dev/book/contributing/) for the details.
